### PR TITLE
Fixed mvn site:site

### DIFF
--- a/spring-boot-3x-and-databases/pom.xml
+++ b/spring-boot-3x-and-databases/pom.xml
@@ -84,22 +84,16 @@
         <maven.version>3.9.0</maven.version> <!-- 3.6.3 on Ubuntu 22.04? -->
         <maven-artifact-transfer.version>0.13.1</maven-artifact-transfer.version>
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-        <maven-dependency-tree-plugin.version>3.6.1</maven-dependency-tree-plugin.version>
         <maven-failsafe-plugin.version>3.2.2</maven-failsafe-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
-        <maven-reporting-api.version>3.1.1</maven-reporting-api.version>
         <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
 
         <build-helper-maven-plugin.version>3.4.0</build-helper-maven-plugin.version>
         <error-prone.version>2.3.4</error-prone.version>
 
-        <!--<maven-site-plugin.version>4.0.0-M11</maven-site-plugin.version> -->
-        <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
-        <doxia.version>1.11.1</doxia.version>
-
         <!-- these are tied to the spring boot version -->
         <spring-boot.version>3.3.1</spring-boot.version>
-    	<flyway.version>10.15.2</flyway.version>
+        <flyway.version>10.15.2</flyway.version>
         <jooq.version>3.19.10</jooq.version>
         <postgresql-jdbc.version>42.7.3</postgresql-jdbc.version>
         <testcontainers.version>1.19.8</testcontainers.version>
@@ -342,4 +336,126 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>site</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <maven-checkstyle-plugin.version>3.4.0</maven-checkstyle-plugin.version>
+                <maven-dependency-plugin.version>3.7.1</maven-dependency-plugin.version>
+                <maven-javadoc-plugin.version>3.7.0</maven-javadoc-plugin.version>
+                <maven-jxr-plugin.version>3.4.0</maven-jxr-plugin.version>
+                <maven-pmd-plugin.version>3.24.0</maven-pmd-plugin.version>
+                <maven-project-info-reports-plugin.version>3.6.2</maven-project-info-reports-plugin.version>
+                <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
+                <maven-reporting-api.version>3.1.1</maven-reporting-api.version>
+                <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
+                <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
+                <maven-surefire-report-plugin.version>3.3.1</maven-surefire-report-plugin.version>
+
+                <doxia.version>1.11.1</doxia.version>
+
+                <checkstyle.version>10.17.0</checkstyle.version>
+                <license-maven-plugin.version>2.4.0</license-maven-plugin.version>
+                <owasp-dependency-check.version>10.0.3</owasp-dependency-check.version>
+
+                <!-- implied -->
+                <slf4j.version>2.0.13</slf4j.version>
+                <log4j.version>2.23.1</log4j.version>
+
+                <activation-api.version>2.1.3</activation-api.version>
+                <annotation-api.version>2.1.1</annotation-api.version>
+                <xml.bind-api.version>4.0.2</xml.bind-api.version>
+                <persistence-api.version>3.1.0</persistence-api.version>
+
+                <jackson.version>2.17.1</jackson.version>
+                <hikari.version>5.1.0</hikari.version>
+                <docker-java-api.version>3.3.6</docker-java-api.version>
+                <mockito.version>5.11.0</mockito.version>
+            </properties>
+
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-dependency-plugin</artifactId>
+                            <version>${maven-dependency-plugin.version}</version>
+                        </plugin>
+
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-project-info-reports-plugin</artifactId>
+                            <version>${maven-project-info-reports-plugin.version}</version>
+                        </plugin>
+
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-site-plugin</artifactId>
+                            <version>${maven-site-plugin.version}</version>
+                        </plugin>
+
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-report-plugin</artifactId>
+                            <version>${maven-surefire-report-plugin.version}</version>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <reportSets>
+                            <reportSet>
+                                <reports>
+                                    <report>analyze-report</report>
+                                </reports>
+                            </reportSet>
+                        </reportSets>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-project-info-reports-plugin</artifactId>
+                        <reportSets>
+                            <reportSet>
+                                <reports><!-- select reports -->
+                                    <report>index</report>
+                                    <report>ci-management</report>
+                                    <report>dependencies</report>
+                                    <report>dependency-info</report>
+                                    <report>dependency-management</report>
+                                    <report>distribution-management</report>
+                                    <report>issue-management</report>
+                                    <report>licenses</report>
+                                    <!-- <report>mailing-lists</report> -->
+                                    <report>modules</report>
+                                    <report>plugin-management</report>
+                                    <report>plugins</report>
+                                    <report>scm</report>
+                                    <report>summary</report>
+                                </reports>
+                            </reportSet>
+                        </reportSets>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-report-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </reporting>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Fixed `mvn site:site` by updating dependencies.

In addition I moved all site-related tasks into a new profile: `site`. It is solely for convenience - it avoids polluting the default profile with unnecessary dependencies.

(This was a quick task since the work had already been done in a feature branch - I split it out in order to improve the focus of that feature branch's pull request.)