### PR TITLE
Fixed `mvn javadoc:javadoc`

### DIFF
--- a/spring-boot-3x-and-databases/common/src/main/java/com/coyotesong/examples/containers/package-info.java
+++ b/spring-boot-3x-and-databases/common/src/main/java/com/coyotesong/examples/containers/package-info.java
@@ -1,45 +1,47 @@
 /**
  * TestContainer extensions
- * <p>
+ *
  * The test container(s) have been extended so [Flyway](https://flywaydb.org)
  * will initialize the database schema prior to running any additional
  * initialization scripts. I decided this was the best place to trigger flyway
  * or liquibase after a bit of experimentation.
- * <p>
+ *
  * The test container(s) will also use the improved LogConsumer.
- * <p>
+ *
  * ## Usage
- * <p>
+ *
  * The following code snippet must be added to all test classes. At the moment it must
  * be done in the individual classes, not a base class, unless we add a lot of thread-local
  * logic. (Which may be worth it...)
- * <p>
- * ```java
  *
- * @Container
- * @ServiceConnection // @RestartScope
- * static PostgreSQLContainerWithFlyway<?> postgres = new PostgreSQLContainerWithFlyway<>(
- * "postgres:16-alpine" // , resources
- * );
- * <p>
- * DynamicPropertySource
+ * ```java
+ * {@literal @}Container
+ * {@literal @}ServiceConnection // {@literal @}RestartScope
+ * static PostgreSQLContainerWithFlyway{@literal <?>} postgres = new PostgreSQLContainerWithFlyway{@literal <>}("postgres:16-alpine");
+ *
+ * {@literal @}DynamicPropertySource
  * static void configureProperties(DynamicPropertyRegistry registry) {
- * registry.add("spring.datasource.url", () -> postgres.getJdbcUrl());
- * registry.add("spring.datasource.username", postgres::getUsername);
- * registry.add("spring.datasource.password", postgres::getPassword);
- * registry.add("spring.datasource.driverClassName", postgres::getDriverClassName);
- * registry.add("spring.datasource.testQueryString", postgres::getTestQueryString);
+ *     registry.add("spring.datasource.url", () -> postgres.getJdbcUrl());
+ *     registry.add("spring.datasource.username", postgres::getUsername);
+ *     registry.add("spring.datasource.password", postgres::getPassword);
+ *     registry.add("spring.datasource.driverClassName", postgres::getDriverClassName);
+ *     registry.add("spring.datasource.testQueryString", postgres::getTestQueryString);
  * }
- * @BeforeAll static void startServer() {
- * if (!postgres.isRunning()) {
- * postgres.start();
+ *
+ * {@literal @}BeforeAll
+ * static void startServer() {
+ *     if (!postgres.isRunning()) {
+ *         postgres.start();
+ *     }
  * }
- * }
- * @AfterAll static void shutdownServer() {
- * if (postgres.isRunning()) {
- * postgres.stop();
- * }
+ *
+ * {@literal @}AfterAll
+ * static void shutdownServer() {
+ *     if (postgres.isRunning()) {
+ *         postgres.stop();
+ *     }
  * }
  * ```
  */
+@SuppressWarnings({ "JavadocBlankLines", "JavadocLinkAsPlainText" })
 package com.coyotesong.examples.containers;

--- a/spring-boot-3x-and-databases/pom.xml
+++ b/spring-boot-3x-and-databases/pom.xml
@@ -73,8 +73,8 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>18</maven.compiler.source>
-        <maven.compiler.target>18</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- it looks like we can't inherit either <properties> or <pluginManagement> from parent pom. :-( -->
@@ -228,34 +228,20 @@
                         <maxmem>1024m</maxmem>
                         <encoding>UTF-8</encoding>
                         <compilerArgs>
-                            <arg>-J--add-opens=java.base/java.net=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                            <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                            <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
                             <arg>-XDcompilePolicy=simple</arg>
-                            <!-- disabling error-prone plugin for now as lots of syntactical changes needed -->
-                            <!--
-                            <arg>-Xplugin:ErrorProne
-                                 -Xep:AssertEqualsArgumentOrderChecker:ERROR
-                                 -Xep:DefaultCharset:ERROR
-                                 -Xep:EqualsIncompatibleType:ERROR
-                                 -Xep:ImmutableEnumChecker:ERROR
-                                 -Xep:MissingOverride:ERROR
-                                 -Xep:RemoveUnusedImports:ERROR
-                                 -Xep:StreamResourceLeak:ERROR
-                                 -Xep:ThreadLocalUsage:ERROR
-                                 -Xep:UnusedException:ERROR
-                                 -Xep:UnnecessaryParentheses:ERROR
-                                 -XepDisableWarningsInGeneratedCode
-                                 -XepExcludedPaths:.*/generated-sources/.*</arg>
-                            -->
                             <arg>-Xlint:all</arg>
                             <arg>-parameters</arg>
                         </compilerArgs>
-                        <annotationProcessorPaths>
-                            <path>
-                                <groupId>com.google.errorprone</groupId>
-                                <artifactId>error_prone_core</artifactId>
-                                <version>${error-prone.version}</version>
-                            </path>
-                        </annotationProcessorPaths>
                     </configuration>
                 </plugin>
 
@@ -375,6 +361,9 @@
                 <hikari.version>5.1.0</hikari.version>
                 <docker-java-api.version>3.3.6</docker-java-api.version>
                 <mockito.version>5.11.0</mockito.version>
+
+                <!-- implied by spring-boot -->
+                <springframework.version>6.1.10</springframework.version>
             </properties>
 
             <build>
@@ -384,6 +373,151 @@
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-dependency-plugin</artifactId>
                             <version>${maven-dependency-plugin.version}</version>
+                        </plugin>
+
+                        <!-- javadoc can contain markdown instead of html. Still produces html. -->
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <!-- do not use 3.5.1: transitive dependencies of docletArtifact are not added to
+                                 docletpath, version 3.5.1 resolves this issue. https://issues.apache.org/jira/browse/  MJAVADOC-742 -->
+                            <version>${maven-javadoc-plugin.version}</version>
+                            <executions>
+                                <execution>
+                                    <id>attach-sources</id>
+                                    <goals>
+                                        <goal>jar</goal>
+                                        <goal>test-jar</goal>
+                                    </goals>
+                                </execution>
+                                <execution>
+                                    <id>aggregate</id>
+                                    <goals>
+                                        <goal>aggregate</goal>
+                                    </goals>
+                                    <phase>site</phase>
+                                    <configuration>
+                                        <!-- Specific configuration for the aggregate report -->
+                                    </configuration>
+                                </execution>
+                                <execution>
+                                    <id>resource-bundles</id>
+                                    <phase>package</phase>
+                                    <goals>
+                                        <!-- produce source artifact for main project sources -->
+                                        <goal>resource-bundle</goal>
+
+                                        <!-- produce source artifact for project test sources -->
+                                        <goal>test-resource-bundle</goal>
+                                    </goals>
+                                    <configuration>
+                                        <detectOfflineLinks>false</detectOfflineLinks>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                            <configuration>
+                                <useStandardDocletOptions>true</useStandardDocletOptions>
+                                <doclet>org.jdrupes.mdoclet.MDoclet</doclet>
+                                <docletArtifacts>
+                                    <docletArtifact>
+                                        <groupId>org.jdrupes.mdoclet</groupId>
+                                        <artifactId>doclet</artifactId>
+                                        <version>4.2.0</version>
+                                    </docletArtifact>
+                                    <docletArtifact>
+                                        <groupId>com.vladsch.flexmark</groupId>
+                                        <artifactId>flexmark-all</artifactId>
+                                        <version>0.64.8</version>
+                                    </docletArtifact>
+                                </docletArtifacts>
+                                <!--  Note: additionalDependencies are added to the -classpath, not the docletpath -->
+                                <additionalDependencies>
+                                </additionalDependencies>
+                                <additionalJOptions>
+                                    <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.doclint=ALL-UNNAMED</additionalJOption>
+                                    <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</additionalJOption>
+                                    <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</additionalJOption>
+                                    <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</additionalJOption>
+                                    <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</additionalJOption>
+                                    <additionalJOption>-J--add-exports=jdk.javadoc/jdk.javadoc.internal.doclets.toolkit=ALL-UNNAMED</additionalJOption>
+                                    <additionalJOption>-J--add-exports=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED</additionalJOption>
+                                </additionalJOptions>
+                                <detectLinks>false</detectLinks>
+                                <links>
+                                    <link>https://docs.oracle.com/en/java/javase/${maven.compiler.target}/docs/api/</link>
+                                    <link>https://docs.oracle.com/en/java/javase/${maven.compiler.target}/docs/api/java.base/</link>
+
+                                    <link>https://javadoc.io/dock/jakarta.activation/jakarta.activation-api/${activation-api.version}</link>
+                                    <link>https://javadoc.io/doc/jakarta.annotation/jakarata.annotation-api/${annotation-api.version}/</link>
+                                    <link>https://javadoc.io/doc/jakarta.persistence/jakarta.persistence-api/${persistence-api.version}/</link>
+                                    <link>https://javadoc.io/doc/jakarta.xml.bind/jakarta.xml.bind-api/${xml.bind-api.version}/</link>
+
+                                    <link>https://javadoc.io/doc/org.slf4j/slf4j-api/${slf4j.version}/</link>
+                                    <link>https://javadoc.io/doc/org.apache.logging/log4j-api/${log4j.version}/</link>
+
+                                    <!-- testing -->
+                                    <link>https://javadoc.io/doc/org.junit.jupiter/junit-jupiter-api/5.10.2/</link>
+                                    <link>https://javadoc.io/doc/junit/junit/4.13.2/</link> <!-- for org.junit.rules.TestRule -->
+
+                                    <link>https://javadoc.io/doc/org.hamcrest/hamcrest/${hamcrest.version}</link>
+                                    <link>https://javadoc.io/doc/org.hamcrest/hamcrest-core/${hamcrest.version}</link>
+                                    <link>https://javadoc.io/doc/org.mockito/mockito-core/${mockito.version}/</link>
+                                    <link>https://javadoc.io/doc/org.mockito/mockito-junit-jupiter/${mockito.version}/</link>
+                                    <link>https://javadoc.io/doc/org.testcontainers/junit-jupiter-api/${testcontainers.version}/</link>
+
+                                    <!-- test containers and docker -->
+                                    <link>https://javadoc.io/doc/com.github.docker-java/docker-java-api/${docker-java-api.version}</link>
+                                    <link>https://javadoc.io/doc/org.testcontainers/testcontainers/${testcontainers.version}/</link>
+
+                                    <link>https://javadoc.io/doc/org.testcontainers/database-commons/${testcontainers.version}/</link>
+                                    <link>https://javadoc.io/doc/org.testcontainers/jdbc/${testcontainers.version}/</link>
+                                    <link>https://javadoc.io/doc/org.testcontainers/postgresql/${testcontainers.version}/</link>
+
+                                    <!-- spring -->
+                                    <link>https://javadoc.io/doc/org.springframework/spring-aop/${springframework.version}/</link>
+                                    <link>https://javadoc.io/doc/org.springframework/spring-beans/${springframework.version}/</link>
+                                    <link>https://javadoc.io/doc/org.springframework/spring-context/${springframework.version}/</link>
+                                    <link>https://javadoc.io/doc/org.springframework/spring-core/${springframework.version}/</link>
+                                    <link>https://javadoc.io/doc/org.springframework/spring-expression/${springframework.version}/</link>
+                                    <link>https://javadoc.io/doc/org.springframework/spring-jcl/${springframework.version}/</link>
+                                    <link>https://javadoc.io/doc/org.springframework/spring-jdbc/${springframework.version}/</link>
+                                    <link>https://javadoc.io/doc/org.springframework/spring-test/${springframework.version}/</link>
+                                    <link>https://javadoc.io/doc/org.springframework/spring-tx/${springframework.version}/</link>
+
+                                    <!-- spring boot -->
+                                    <link>https://javadoc.io/doc/org.springframework.boot/spring-boot-autoconfigure/${spring-boot.version}/</link>
+                                    <link>https://javadoc.io/doc/org.springframework.boot/spring-boot-test/${spring-boot.version}/</link>
+                                    <link>https://javadoc.io/doc/org.springframework.boot/spring-boot-test-autoconfigure/${spring-boot.version}/</link>
+                                    <link>https://javadoc.io/doc/org.springframework.boot/spring-boot-testcontainers/${spring-boot.version}/</link>
+
+                                    <!-- jooq -->
+                                    <link>https://javadoc.io/doc/org.jooq/jooq/${jooq.version}/</link>
+                                    <link>https://javadoc.io/doc/org.flywaydb/flyway-core/${flyway.version}/</link>
+                                    <link>https://javadoc.io/doc/org.flywaydb/flyway-database-postgresql/${flyway.version}/</link>
+                                    <link>https://javadoc.io/doc/com.zaxxer/HikariCP/${hikari.version}/</link>
+
+                                    <!-- jackson -->
+                                    <link>https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-annotations/${jackson.version}/</link>
+                                    <link>https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-core/${jackson.version}/</link>
+                                    <link>https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/${jackson.version}/</link>
+                                    <link>https://javadoc.io/doc/com.fasterxml.jackson.dataformat/jackson-dataformat-toml/${jackson.version}/</link>
+
+                                    <link>https://javadoc.io/doc/com.google.code.son/gson/2.10.1/</link>
+
+                                    <link>https://javadoc.io/doc/org.apache.commons/commons-compress/1.24.0/</link>
+                                    <link>https://javadoc.io/doc/org.apache.commons/commons-lang3/3.13.0</link>
+
+                                    <link>https://javadoc.io/doc/org.jetbrains/annotations/${jetbrains.version}/</link>
+
+                                    <!-- test scope -->
+                                    <link>https://javadoc.io/doc/com.google.errorprone/error_prone_annotations/2.21.1/</link>
+                                    <link>https://javadoc.io/doc/com.jayway.jsonpath/json-path/2.9.0/</link>
+                                    <link>https://javadoc.io/doc/commons-codec/commons-codec/1.16.1/</link>
+                                    <link>https://javadoc.io/doc/commons-logging/commons-logging/1.2/</link>
+                                    <link>https://javadoc.io/doc/org.xml/xmlunit-core/2.9.1</link>
+                                    <link>https://javadoc.io/doc/org.yaml/snakeyaml/2.2/</link>
+                                </links>
+                            </configuration>
                         </plugin>
 
                         <plugin>
@@ -405,7 +539,30 @@
                         </plugin>
                     </plugins>
                 </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-site-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-report-plugin</artifactId>
+                    </plugin>
+                </plugins>
             </build>
+
             <reporting>
                 <plugins>
                     <plugin>
@@ -420,6 +577,26 @@
                             <reportSet>
                                 <reports>
                                     <report>analyze-report</report>
+                                </reports>
+                            </reportSet>
+                        </reportSets>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <reportSets>
+                            <reportSet><!-- by default, id = "default" -->
+                                <reports><!-- select non-aggregate reports -->
+                                    <report>javadoc</report>
+                                    <report>test-javadoc</report>
+                                </reports>
+                            </reportSet>
+                            <reportSet><!-- aggregate reportSet, to define in poms having modules -->
+                                <id>aggregate</id>
+                                <inherited>false</inherited><!-- don't run aggregate in child modules -->
+                                <reports>
+                                    <report>aggregate</report>
                                 </reports>
                             </reportSet>
                         </reportSets>


### PR DESCRIPTION
Fixed 'mvn javadoc:javadoc' by:

- [x] bumped to Java 21 (to match installed version)
- [x] added `-J--add-exports` and `-J--add-opens` to maven-compiler-plugin configuration
- [x] added `-J--add-exports` to maven-javadoc-plugin configuration
- [x] added links to https://javadoc.io/